### PR TITLE
New hidingNavigationBarManager property in UIViewController

### DIFF
--- a/HidingNavigationBar/HidingNavigationBarManager.swift
+++ b/HidingNavigationBar/HidingNavigationBarManager.swift
@@ -385,11 +385,11 @@ public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestu
 
 //MARK: Extensions
 
-private struct AssociatedKeys {
-    static var hidingNavigationBarManager = "hidingNavigationBarManager"
-}
-
 extension UIViewController {
+    private struct AssociatedKeys {
+        static var hidingNavigationBarManager = "hidingNavigationBarManager"
+    }
+    
     public var hidingNavigationBarManager: HidingNavigationBarManager? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.hidingNavigationBarManager) as? HidingNavigationBarManager
@@ -402,11 +402,6 @@ extension UIViewController {
     public override class func initialize() {
         struct Static {
             static var token: dispatch_once_t = 0
-        }
-        
-        // make sure this isn't a subclass
-        if self !== UIViewController.self {
-            return
         }
         
         dispatch_once(&Static.token) {

--- a/HidingNavigationBarSample/HidingNavigationBarSample.xcodeproj/project.pbxproj
+++ b/HidingNavigationBarSample/HidingNavigationBarSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5D5D91081C45DF370061D461 /* HidingNavInternalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5D91071C45DF370061D461 /* HidingNavInternalViewController.swift */; };
 		6A412A2E1BB1CBA4001C3F67 /* HidingNavigationBar.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A412A2D1BB1CBA4001C3F67 /* HidingNavigationBar.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6A412A401BB1CBA4001C3F67 /* HidingNavigationBar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A412A2B1BB1CBA4001C3F67 /* HidingNavigationBar.framework */; };
 		6A412A411BB1CBA4001C3F67 /* HidingNavigationBar.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6A412A2B1BB1CBA4001C3F67 /* HidingNavigationBar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -58,6 +59,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5D5D91071C45DF370061D461 /* HidingNavInternalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HidingNavInternalViewController.swift; sourceTree = "<group>"; };
 		6A412A2B1BB1CBA4001C3F67 /* HidingNavigationBar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HidingNavigationBar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A412A2D1BB1CBA4001C3F67 /* HidingNavigationBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HidingNavigationBar.h; sourceTree = "<group>"; };
 		6A412A2F1BB1CBA4001C3F67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -153,12 +155,13 @@
 				6A6570ED1AF3F71100A6CFE4 /* AppDelegate.swift */,
 				6A6570EF1AF3F71100A6CFE4 /* MasterViewController.swift */,
 				6A6571111AF3F8D900A6CFE4 /* HidingNavViewController.swift */,
+				5D5D91071C45DF370061D461 /* HidingNavInternalViewController.swift */,
 				6A65711D1AF3FDB600A6CFE4 /* HidingNavExtensionViewController.swift */,
-				6A6571231AF40E7000A6CFE4 /* HidingNavTabViewController.swift */,
 				6A65711F1AF408C000A6CFE4 /* HidingNavToolbarViewController.swift */,
-				6A6570F31AF3F71100A6CFE4 /* Main.storyboard */,
+				6A6571231AF40E7000A6CFE4 /* HidingNavTabViewController.swift */,
 				6A6570F61AF3F71100A6CFE4 /* Images.xcassets */,
 				6A6570F81AF3F71100A6CFE4 /* LaunchScreen.xib */,
+				6A6570F31AF3F71100A6CFE4 /* Main.storyboard */,
 				6A6570EB1AF3F71100A6CFE4 /* Supporting Files */,
 			);
 			path = HidingNavigationBarSample;
@@ -359,6 +362,7 @@
 				6A6570EE1AF3F71100A6CFE4 /* AppDelegate.swift in Sources */,
 				6A6571121AF3F8D900A6CFE4 /* HidingNavViewController.swift in Sources */,
 				6A65711C1AF3FADC00A6CFE4 /* HidingViewController.swift in Sources */,
+				5D5D91081C45DF370061D461 /* HidingNavInternalViewController.swift in Sources */,
 				6A65711E1AF3FDB600A6CFE4 /* HidingNavExtensionViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HidingNavigationBarSample/HidingNavigationBarSample/HidingNavInternalViewController.swift
+++ b/HidingNavigationBarSample/HidingNavigationBarSample/HidingNavInternalViewController.swift
@@ -1,0 +1,59 @@
+//
+//  HidingNavInternalViewController.swift
+//  HidingNavigationBarSample
+//
+//  Created by felipowsky on 1/12/16.
+//  Copyright © 2016 Tristan Himmelman. All rights reserved.
+//
+
+import UIKit
+
+class HidingNavInternalViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    
+    let identifier = "cell"
+    var tableView: UITableView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        tableView = UITableView(frame: view.bounds)
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.registerClass(UITableViewCell.classForCoder(), forCellReuseIdentifier: identifier)
+        view.addSubview(tableView)
+        
+        hidingNavigationBarManager = HidingNavigationBarManager(viewController: self, scrollView: tableView)
+    }
+    
+    // MARK: UITableViewDelegate
+    
+    func scrollViewShouldScrollToTop(scrollView: UIScrollView) -> Bool {
+        hidingNavigationBarManager?.shouldScrollToTop()
+        
+        return true
+    }
+    
+    // MARK: - UITableViewDataSource
+    
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        // #warning Potentially incomplete method implementation.
+        // Return the number of sections.
+        return 1
+    }
+    
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete method implementation.
+        // Return the number of rows in the section.
+        return 100
+    }
+    
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier(identifier, forIndexPath: indexPath)
+        
+        // Configure the cell...
+        cell.textLabel?.text = "row \(indexPath.row)"
+        cell.selectionStyle = UITableViewCellSelectionStyle.None
+        
+        return cell
+    }
+}

--- a/HidingNavigationBarSample/HidingNavigationBarSample/MasterViewController.swift
+++ b/HidingNavigationBarSample/HidingNavigationBarSample/MasterViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class MasterViewController: UITableViewController {
 	
-	let rows = ["Hiding Nav Bar", "Hiding Nav Bar + Extension View", "Hiding Nav Bar + Toolbar", "Hiding Nav Bar + TabBar"]
+	let rows = ["Hiding Nav Bar", "Hiding Nav Bar (Internal)", "Hiding Nav Bar + Extension View", "Hiding Nav Bar + Toolbar", "Hiding Nav Bar + TabBar"]
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -59,10 +59,13 @@ class MasterViewController: UITableViewController {
 		if indexPath.row == 0 {
 			let controller = HidingNavViewController()
 			navigationController?.pushViewController(controller, animated: true)
-		} else if indexPath.row == 1 {
+        } else if indexPath.row == 1 {
+            let controller = HidingNavInternalViewController()
+            navigationController?.pushViewController(controller, animated: true)
+		} else if indexPath.row == 2 {
 			let controller = HidingNavExtensionViewController()
 			navigationController?.pushViewController(controller, animated: true)
-		} else if indexPath.row == 2 {
+		} else if indexPath.row == 3 {
 			let controller = HidingNavToolbarViewController()
 			navigationController?.pushViewController(controller, animated: true)
 		} else {


### PR DESCRIPTION
- Added `hidingNavigationBarManager` property in UIViewController by extension
- Swizzled `viewWillAppear`, `viewDidLayoutSubviews` and `viewWillDisappear` to use the new `hidingNavigationBarManager` property
- Added new example: `Hiding Nav Bar (Internal)`

`hidingNavigationBarManager` property isn't required. Once attributed it isn't necessary to implement `viewWillAppear`, `viewDidLayoutSubviews` or `viewWillDisappear`.

It's still necessary to implement `scrollViewShouldScrollToTop` in order to enable scroll to top.
