### PR TITLE
Enabled extendedLayoutIncludesOpaqueBars

### DIFF
--- a/HidingNavigationBar/HidingNavigationBarManager.swift
+++ b/HidingNavigationBar/HidingNavigationBarManager.swift
@@ -56,6 +56,9 @@ public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestu
 		if viewController.navigationController == nil || viewController.navigationController?.navigationBar == nil {
 			fatalError("ViewController must be within a UINavigationController")
 		}
+        
+        viewController.extendedLayoutIncludesOpaqueBars = true
+        
 		self.viewController = viewController
 		self.scrollView = scrollView
 		


### PR DESCRIPTION
Enabled `viewcontroller`'s `extendedLayoutIncludesOpaqueBars`.
Solved a problem where UIViewController's `view` was smaller than the size of the screen.

I capture an example using Debug View Hierarchy from the same view to illustrate the problem I was facing.

 `extendedLayoutIncludesOpaqueBars` disabled:
![wo_extended](https://cloud.githubusercontent.com/assets/1298990/12378238/147a48b0-bd1f-11e5-81d5-bc92cd6077e3.png)

 `extendedLayoutIncludesOpaqueBars` enabled:
![w_extended](https://cloud.githubusercontent.com/assets/1298990/12378237/14732e4a-bd1f-11e5-9cf0-b08618d7ee57.png)
