### PR TITLE
Fix navigation bar and extension view hiding suddenly

### DIFF
--- a/HidingNavigationBar/HidingNavigationBarManager.swift
+++ b/HidingNavigationBar/HidingNavigationBarManager.swift
@@ -266,7 +266,6 @@ public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestu
 			if currentState != previousState {
 				previousState = currentState
 				resistanceConsumed = 0
-				//println("new state \(currentState.rawValue)")
 			}
 			
 			// 5 - Apply resistance
@@ -356,6 +355,8 @@ public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestu
 				self.updateScrollContentInsetTop(top)
 				self.scrollView.contentOffset = newContentOffset
 			}
+            
+            previousYOffset = CGFloat.NaN
 		}
 	}
 	


### PR DESCRIPTION
Right after a small pan gesture that wasn't enough to hide the navigation bar and the extension view, if   pan gesture is fired again the navigation and the extension hide suddenly.

I noticed this bug happening more frequently with an extension view but I think it's possible to simulate it in other scenarios.

Here an example:
![nav_bug](https://cloud.githubusercontent.com/assets/1298990/12404107/f3b96bae-be1f-11e5-921f-6d69bc81cc30.gif)

Fixed it by resetting the `previousYOffset` at `handleScrollingEnded` to `NaN`.

Here's the expected result:
![nav_fix](https://cloud.githubusercontent.com/assets/1298990/12404152/32377254-be20-11e5-8487-8a421bfd52b0.gif)
