### PR TITLE
Add Option to Show/Hide NavigationBar + ToolBar on Foreground

### DIFF
--- a/HidingNavigationBar/HidingNavigationBarManager.swift
+++ b/HidingNavigationBar/HidingNavigationBarManager.swift
@@ -20,6 +20,12 @@ public enum HidingNavigationBarState: String {
 	case Open			= "Open"
 }
 
+public enum HidingNavigationForegroundAction {
+	case Default
+	case Show
+	case Hide
+}
+
 public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestureRecognizerDelegate {
 	// The view controller that is part of the navigation stack
 	unowned var viewController: UIViewController
@@ -51,6 +57,9 @@ public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestu
 	// Hiding navigation bar state
 	private var currentState = HidingNavigationBarState.Open
 	private var previousState = HidingNavigationBarState.Open
+
+	//Options
+	public var onForegroundAction = HidingNavigationForegroundAction.Default
 	
 	public init(viewController: UIViewController, scrollView: UIScrollView){
 		if viewController.navigationController == nil || viewController.navigationController?.navigationBar == nil {
@@ -93,7 +102,7 @@ public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestu
 		
 		updateContentInsets()
 		
-		NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("applicationDidBecomeActive"), name: UIApplicationDidBecomeActiveNotification, object: nil)
+		NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("applicationWillEnterForeground"), name: UIApplicationDidBecomeActiveNotification, object: nil)
 	}
 	
 	deinit {
@@ -197,9 +206,17 @@ public class HidingNavigationBarManager: NSObject, UIScrollViewDelegate, UIGestu
 	
 	//MARK: NSNotification
 	
-	func applicationDidBecomeActive() {
-		navBarController.expand()
-		tabBarController?.expand()
+	func applicationWillEnterForeground() {
+		switch onForegroundAction {
+		case .Show:
+			navBarController.expand()
+			tabBarController?.expand()
+		case .Hide:
+			navBarController.contract()
+			tabBarController?.contract()
+		default:
+			break;
+		}
 	}
 	
 	//MARK: Private methods

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ if let tabBar = navigationController?.tabBarController?.tabBar {
 }
 ```
 
+###Hide/Show/Do Nothing when App is Foregrounded
+```swift
+	hidingNavBarManager?.onForegroundAction = .Default	//Do nothing, state of bars will remain the same as when backgrounded
+	hidingNavBarManager?.onForegroundAction = .Hide		//Always hide on foreground
+	hidingNavBarManager?.onForegroundAction = .Show 	//Always show on foreground
+```
+
 ###Expansion Resistance 
 When the navigation bar is hidden, you can some 'resitance' which adds a delay before the navigation bar starts to expand when scrolling. The resistance value is the distance that the user needs to scroll before the navigation bar starts to expand.
 ```swift


### PR DESCRIPTION
### Replace UIApplicationDidBecomeActive with UIApplicationWillEnterForeground
- UIApplicationWillEnterForeground is called before UIApplicationDidBecomeActive, except for when the application is first launched, where UIApplicationWillEnterForeground is not called at all. However, I believe it is better to give the developer better control over what the HidingNavigationBar does on startup, which UIApplicationDidBecomeActive will interfere with
### Add options to determine the action to take on foreground event
- Default is to take no action, so the navigation bar state is consistent between background/foreground events. Show and Hide are available as well, in the event a developer finds it useful.
