### PR TITLE
Updated for iOS 11.

### DIFF
--- a/HidingNavigationBar/HidingViewController.swift
+++ b/HidingNavigationBar/HidingViewController.swift
@@ -162,6 +162,14 @@ class HidingViewController {
 	}
 	
 	// MARK: - Private methods
+    
+    // Recursively applies an operation to all views in a view hierarchy
+    fileprivate func applyToViewHierarchy(rootView: UIView, operation: (UIView) -> Void) {
+        operation(rootView)
+        rootView.subviews.forEach { view in
+            applyToViewHierarchy(rootView: view, operation: operation)
+        }
+    }
 	
 	fileprivate func updateSubviewsToAlpha(_ alpha: CGFloat) {
 		if navSubviews == nil {
@@ -177,11 +185,10 @@ class HidingViewController {
 				}
 			}
 		}
-		
-		if let subViews = navSubviews {
-			for subView in subViews {
-				subView.alpha = alpha
-			}
-		}
+        navSubviews?.forEach { subView in
+            applyToViewHierarchy(rootView: subView) { view in
+                view.alpha = alpha
+            }
+        }
 	}
 }


### PR DESCRIPTION
The structure of `UINavigationBar` has changed in iOS 11. This meant that navigation bar was not fading out and was clashing with the status bar. I modified the code to recursively apply the new alpha value. The change should be benign on older OS versions.

This PR may solve issue #67.

